### PR TITLE
Feat: Add SwiftUI Preview Extension

### DIFF
--- a/dorm/dorm.xcodeproj/project.pbxproj
+++ b/dorm/dorm.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		002789C02886496E00BDCDA4 /* UIKitPreviewExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 002789BF2886496E00BDCDA4 /* UIKitPreviewExtension.swift */; };
 		007C698D28858A3D0074F653 /* Student.swift in Sources */ = {isa = PBXBuildFile; fileRef = 007C698C28858A3D0074F653 /* Student.swift */; };
 		007C698F28858C210074F653 /* DormRoom.swift in Sources */ = {isa = PBXBuildFile; fileRef = 007C698E28858C210074F653 /* DormRoom.swift */; };
 		00F2D835288049DE00BE4176 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00F2D834288049DE00BE4176 /* AppDelegate.swift */; };
@@ -18,6 +19,7 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		002789BF2886496E00BDCDA4 /* UIKitPreviewExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIKitPreviewExtension.swift; sourceTree = "<group>"; };
 		007C698C28858A3D0074F653 /* Student.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Student.swift; sourceTree = "<group>"; };
 		007C698E28858C210074F653 /* DormRoom.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DormRoom.swift; sourceTree = "<group>"; };
 		00F2D831288049DE00BE4176 /* dorm.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = dorm.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -116,6 +118,7 @@
 		00FA1BBC288504240087929B /* Extension */ = {
 			isa = PBXGroup;
 			children = (
+				002789BF2886496E00BDCDA4 /* UIKitPreviewExtension.swift */,
 			);
 			path = Extension;
 			sourceTree = "<group>";
@@ -226,6 +229,7 @@
 				007C698F28858C210074F653 /* DormRoom.swift in Sources */,
 				00F2D835288049DE00BE4176 /* AppDelegate.swift in Sources */,
 				007C698D28858A3D0074F653 /* Student.swift in Sources */,
+				002789C02886496E00BDCDA4 /* UIKitPreviewExtension.swift in Sources */,
 				00F2D837288049DE00BE4176 /* SceneDelegate.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/dorm/dorm/Domain/Model/Student.swift
+++ b/dorm/dorm/Domain/Model/Student.swift
@@ -11,7 +11,7 @@ struct Student: Codable {
     let name: String // 학생 이름
     let nickname: String? // 학생 닉네임
     let roomNumber: Int // 거주하는 방 호수
-    let state: Int //현재 거주 상태
+    let state: Int // 현재 거주 상태
 
     /// Student initializer
     /// - Parameters:

--- a/dorm/dorm/Extension/UIKitPreviewExtension.swift
+++ b/dorm/dorm/Extension/UIKitPreviewExtension.swift
@@ -1,0 +1,53 @@
+//
+//  UIKitPreviewExtension.swift
+//  dorm
+//
+//  Created by JongHo Park on 2022/07/19.
+//
+
+#if DEBUG
+import UIKit
+import SwiftUI
+
+extension UIViewController {
+    public struct UIViewControllerPreview<ViewController: UIViewController>: UIViewControllerRepresentable {
+        public let viewController: ViewController
+
+        public init(_ builder: @autoclosure () -> ViewController) {
+            viewController = builder()
+        }
+
+        // MARK: - UIViewControllerRepresentable
+        public func makeUIViewController(context: Context) -> ViewController {
+            viewController
+        }
+
+        public func updateUIViewController(_ uiViewController: ViewController, context: UIViewControllerRepresentableContext<UIViewControllerPreview<ViewController>>) {
+
+        }
+    }
+
+    func toPreview() -> some View {
+        UIViewControllerPreview(self)
+    }
+}
+
+extension UIView {
+    public struct UIViewPreview<View: UIView>: UIViewRepresentable {
+            public let view: View
+            public init(_ builder: @autoclosure () -> View) {
+                view = builder()
+            }
+            // MARK: - UIViewRepresentable
+            public func makeUIView(context: Context) -> UIView {
+                return view
+            }
+            public func updateUIView(_ view: UIView, context: Context) {
+            }
+        }
+
+    func toPreview() -> some View {
+        UIViewPreview(self)
+    }
+}
+#endif


### PR DESCRIPTION
## Changes

- UIKitPreviewExtension.swift

## New features

- UIKit ViewController 에서 동적으로 SwiftUI Preview 사용 가능
- UIKit View 에서 동적으로 SwiftUI Preview 사용 가능

## Review points

- UIViewController Extension 을 사용해서 UIViewControllerRepresentable 을 정의
- UIView Extension 을 사용해서 UIViewRepresentable 을 정의

## 사용 방법

- ViewController 를 Preview 로 변환하려는 경우 ViewController 파일 하단에 아래 코드를 첨부하면 됩니다.
```swift
#if DEBUG
import SwiftUI
struct PreviewName: PreviewProvider {
    static var previews: some View {
        TestViewController().toPreview()
    }
}
#endif
```
- 만약 Storyboard 에서 ViewController 를 가져온다면, UIStoryboard(name: "Main", bundle: nil).instantiateViewController("TestUIViewController").toPreview() 와 같이 작성해서 사용하시면 됩니다.

- View 를 Preview 변환하려는 경우 UIView 파일 하단에 아래 코드를 첨부하면 됩니다.
```swift
#if DEBUG
import SwiftUI
struct PreviewName: PreviewProvider {
    static var previews: some View {
        TestUIView().toPreview()
    }
}
#endif
```

## References

[블로그](https://taekki-dev.tistory.com/21)

## Checklist

- [x] Is the branch you are merging on correct?
- [x] Do you comply with coding conventions?
- [x] Are there any changes not related to PR?
- [x] Has my code been self-reviewed?
