### PR TITLE
Feat: Set UISplitViewController to RootViewController

### DIFF
--- a/dorm/dorm.xcodeproj/project.pbxproj
+++ b/dorm/dorm.xcodeproj/project.pbxproj
@@ -7,9 +7,9 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		002789C02886496E00BDCDA4 /* UIKitPreviewExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 002789BF2886496E00BDCDA4 /* UIKitPreviewExtension.swift */; };
 		002789BC288641CA00BDCDA4 /* RoomManagerViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 002789BB288641CA00BDCDA4 /* RoomManagerViewController.swift */; };
 		002789BE2886449A00BDCDA4 /* RoomManagerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 002789BD2886449A00BDCDA4 /* RoomManagerView.swift */; };
+		002789C02886496E00BDCDA4 /* UIKitPreviewExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 002789BF2886496E00BDCDA4 /* UIKitPreviewExtension.swift */; };
 		007C698D28858A3D0074F653 /* Student.swift in Sources */ = {isa = PBXBuildFile; fileRef = 007C698C28858A3D0074F653 /* Student.swift */; };
 		007C698F28858C210074F653 /* DormRoom.swift in Sources */ = {isa = PBXBuildFile; fileRef = 007C698E28858C210074F653 /* DormRoom.swift */; };
 		00F2D835288049DE00BE4176 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00F2D834288049DE00BE4176 /* AppDelegate.swift */; };
@@ -21,9 +21,9 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
-		002789BF2886496E00BDCDA4 /* UIKitPreviewExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIKitPreviewExtension.swift; sourceTree = "<group>"; };
 		002789BB288641CA00BDCDA4 /* RoomManagerViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoomManagerViewController.swift; sourceTree = "<group>"; };
 		002789BD2886449A00BDCDA4 /* RoomManagerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoomManagerView.swift; sourceTree = "<group>"; };
+		002789BF2886496E00BDCDA4 /* UIKitPreviewExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIKitPreviewExtension.swift; sourceTree = "<group>"; };
 		007C698C28858A3D0074F653 /* Student.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Student.swift; sourceTree = "<group>"; };
 		007C698E28858C210074F653 /* DormRoom.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DormRoom.swift; sourceTree = "<group>"; };
 		00F2D831288049DE00BE4176 /* dorm.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = dorm.app; sourceTree = BUILT_PRODUCTS_DIR; };

--- a/dorm/dorm/System/SceneDelegate.swift
+++ b/dorm/dorm/System/SceneDelegate.swift
@@ -13,7 +13,12 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 
     func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
 
-//        guard let _ = (scene as? UIWindowScene) else { return }
+        guard let scene = (scene as? UIWindowScene) else { return }
+
+        window = UIWindow(windowScene: scene)
+        window?.rootViewController = UISplitViewController()
+        window?.windowScene = scene
+        window?.makeKeyAndVisible()
     }
 
     func sceneDidDisconnect(_ scene: UIScene) {


### PR DESCRIPTION
## Changes
<img width="500" alt="image" src="https://user-images.githubusercontent.com/103008077/179763126-53118e26-9496-4f21-8f8b-11746d119714.png">

- SceneDelegate.swift

## New features

- [UISplitViewController를 rootViewController로 설정](https://github.com/DeveloperAcademy-POSTECH/MC3-Team-18-Momin/blob/fa41c77324cdaedab438ec9aeae2cb212945a0c6/dorm/dorm/System/SceneDelegate.swift)

## Review points

- SceneDelegate에서 rootViewcontroller를 SplitViewController로 변경할 수 있다

## Questions

- 제가 맞게 잘한 거겠죠...? (커밋에 오타난 건 죄송합니다 금차차!)

## References

- [SceneDelegate에서 rootViewController 변경](https://it-highjune.tistory.com/11)

## Checklist

- [x] Is the branch you are merging on correct?
- [x] Do you comply with coding conventions?
- [x] Are there any changes not related to PR?
- [x] Has my code been self-reviewed?
