### PR TITLE
Feat: Add DocumentPickerViewController

### DIFF
--- a/dorm/dorm.xcodeproj/project.pbxproj
+++ b/dorm/dorm.xcodeproj/project.pbxproj
@@ -22,6 +22,7 @@
 		00FA1BC1288522D90087929B /* .swiftlint.yml in Resources */ = {isa = PBXBuildFile; fileRef = 00FA1BC0288522D90087929B /* .swiftlint.yml */; };
 		2A0388BD28878BD800B5DAD5 /* ColorExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A0388BC28878BD800B5DAD5 /* ColorExtension.swift */; };
 		C9F39AC42887935500CD0F3F /* MockDatas.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9F39AC32887935500CD0F3F /* MockDatas.swift */; };
+		2A0388BB28863EF300B5DAD5 /* DocumentPickerViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A0388BA28863EF300B5DAD5 /* DocumentPickerViewController.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -42,6 +43,7 @@
 		00FA1BC0288522D90087929B /* .swiftlint.yml */ = {isa = PBXFileReference; lastKnownFileType = text.yaml; path = .swiftlint.yml; sourceTree = "<group>"; };
 		2A0388BC28878BD800B5DAD5 /* ColorExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ColorExtension.swift; sourceTree = "<group>"; };
 		C9F39AC32887935500CD0F3F /* MockDatas.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockDatas.swift; sourceTree = "<group>"; };
+		2A0388BA28863EF300B5DAD5 /* DocumentPickerViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DocumentPickerViewController.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -127,6 +129,7 @@
 			children = (
 				00F789E228878E51001D5AF8 /* SplitView */,
 				002789BA288641BC00BDCDA4 /* RoomManager */,
+				2A0388B928863EDC00B5DAD5 /* DocumentPickerView */,
 			);
 			path = Presenter;
 			sourceTree = "<group>";
@@ -164,6 +167,14 @@
 				00F2D836288049DE00BE4176 /* SceneDelegate.swift */,
 			);
 			path = System;
+			sourceTree = "<group>";
+		};
+		2A0388B928863EDC00B5DAD5 /* DocumentPickerView */ = {
+			isa = PBXGroup;
+			children = (
+				2A0388BA28863EF300B5DAD5 /* DocumentPickerViewController.swift */,
+			);
+			path = DocumentPickerView;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -271,6 +282,7 @@
 				00F2D837288049DE00BE4176 /* SceneDelegate.swift in Sources */,
 				008A5F542887A372006B202C /* ScreenState.swift in Sources */,
 				002789BC288641CA00BDCDA4 /* RoomManagerViewController.swift in Sources */,
+				2A0388BB28863EF300B5DAD5 /* DocumentPickerViewController.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/dorm/dorm/Base.lproj/Main.storyboard
+++ b/dorm/dorm/Base.lproj/Main.storyboard
@@ -1,24 +1,46 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13122.16" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
+    <device id="ipad11_0rounded" orientation="portrait" layout="fullscreen" appearance="light"/>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13104.12"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
-        <!--View Controller-->
+        <!--Document Picker View Controller-->
         <scene sceneID="tne-QT-ifu">
             <objects>
-                <viewController id="BYZ-38-t0r" customClass="ViewController" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController id="BYZ-38-t0r" customClass="DocumentPickerViewController" customModule="dorm" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <rect key="frame" x="0.0" y="0.0" width="834" height="1194"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                        <color key="backgroundColor" xcode11CocoaTouchSystemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                        <subviews>
+                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="82n-BL-d2A">
+                                <rect key="frame" x="380" y="580" width="75" height="35"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <state key="normal" title="Button"/>
+                                <buttonConfiguration key="configuration" style="plain" title="Button"/>
+                                <connections>
+                                    <action selector="didTapUploadFileWithSender:" destination="BYZ-38-t0r" eventType="touchUpInside" id="Y50-TQ-jsE"/>
+                                </connections>
+                            </button>
+                        </subviews>
                         <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                     </view>
+                    <connections>
+                        <outlet property="openDocumentButton" destination="82n-BL-d2A" id="rJl-sV-G6B"/>
+                    </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
             </objects>
+            <point key="canvasLocation" x="61" y="52"/>
         </scene>
     </scenes>
+    <resources>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+    </resources>
 </document>

--- a/dorm/dorm/Presenter/DocumentPickerView/DocumentPickerViewController.swift
+++ b/dorm/dorm/Presenter/DocumentPickerView/DocumentPickerViewController.swift
@@ -1,0 +1,45 @@
+//
+//  DocumentPickerViewController.swift
+//  dorm
+//
+//  Created by 한택환 on 2022/07/19.
+//
+
+import UIKit
+import UniformTypeIdentifiers
+
+final class DocumentPickerViewController: UIViewController {
+    //TODO: - 임시 UIDocumentPickerViewController를 불러오기 위한 버튼
+    @IBOutlet weak var openDocumentButton: UIButton!
+    private var csvUrl: URL?
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        setOpenDocumentButton()
+    }
+    @IBAction func didTapUploadFile(sender: UIButton) {
+        if presentedViewController == nil {
+            let csvTypes: [UTType] = [.data]
+            let documentPicker = UIDocumentPickerViewController(forOpeningContentTypes: csvTypes, asCopy: true)
+            documentPicker.delegate = self
+            documentPicker.modalPresentationStyle = .pageSheet
+            present(documentPicker, animated: true)
+        }
+    }
+}
+extension DocumentPickerViewController: UIDocumentPickerDelegate {
+    func setOpenDocumentButton() {
+        openDocumentButton.frame.size = CGSize(width: 300, height: 50)
+        openDocumentButton.center = CGPoint(x: UIScreen.main.bounds.width - 60, y: 60)
+        openDocumentButton.setTitle("import", for: .normal)
+        openDocumentButton.setTitleColor(UIColor.red, for: .normal)
+    }
+    func documentPicker(_ controller: UIDocumentPickerViewController, didPickDocumentAt url: URL) {
+        dismiss(animated: true)
+        guard url.startAccessingSecurityScopedResource() else {
+            url.stopAccessingSecurityScopedResource()
+            return
+        }
+        url.stopAccessingSecurityScopedResource()
+        csvUrl = url
+    }
+}


### PR DESCRIPTION
## Changes
![Simulator Screen Recording - iPad Pro (11-inch) (3rd generation) - 2022-07-21 at 01 39 41](https://user-images.githubusercontent.com/103012087/180036780-9dbed4e4-2e62-4b6a-b1cd-aab4092e8db8.gif)
    - DocumentPickerViewController.swift

## New features

- DocumentPickerViewController 추가

## Review points

- RoomManagerViewController 에서 호출 시 UIDocumentPickerViewController를 사용할 수 있다.
- csvUrl 변수에 임시로 선택한 문서의 url 저장할 수 있다
- 임시로 UIButton 만들어 UIDocumentPickerViewController를 호출하도록 했다.

## References

- https://developer.apple.com/documentation/uikit/uidocumentpickerviewcontroller

## Checklist

- [x] Is the branch you are merging on correct?
- [x] Do you comply with coding conventions?
- [x] Are there any changes not related to PR?
- [x] Has my code been self-reviewed?
