### PR TITLE
Feat: Add DocumentPickerViewModel and .csv to StudentEntity Convertor

### DIFF
--- a/dorm/dorm.xcodeproj/project.pbxproj
+++ b/dorm/dorm.xcodeproj/project.pbxproj
@@ -38,6 +38,9 @@
 		2A0388BB28863EF300B5DAD5 /* DocumentPickerViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A0388BA28863EF300B5DAD5 /* DocumentPickerViewController.swift */; };
 		2A0388BD28878BD800B5DAD5 /* ColorExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A0388BC28878BD800B5DAD5 /* ColorExtension.swift */; };
 		C9E2C9FB2892235200DF5C70 /* RoomCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9E2C9FA2892235200DF5C70 /* RoomCollectionViewCell.swift */; };
+		2A0388BB28863EF300B5DAD5 /* DocumentPickerViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A0388BA28863EF300B5DAD5 /* DocumentPickerViewController.swift */; };
+		2A0388BD28878BD800B5DAD5 /* ColorExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A0388BC28878BD800B5DAD5 /* ColorExtension.swift */; };
+		2A68A07528921E5C004BC6A0 /* DocumentPickerViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A68A07428921E5C004BC6A0 /* DocumentPickerViewModel.swift */; };
 		C9F39AC42887935500CD0F3F /* MockDatas.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9F39AC32887935500CD0F3F /* MockDatas.swift */; };
 /* End PBXBuildFile section */
 
@@ -84,6 +87,9 @@
 		2A0388BA28863EF300B5DAD5 /* DocumentPickerViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DocumentPickerViewController.swift; sourceTree = "<group>"; };
 		2A0388BC28878BD800B5DAD5 /* ColorExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ColorExtension.swift; sourceTree = "<group>"; };
 		C9E2C9FA2892235200DF5C70 /* RoomCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoomCollectionViewCell.swift; sourceTree = "<group>"; };
+		2A0388BA28863EF300B5DAD5 /* DocumentPickerViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DocumentPickerViewController.swift; sourceTree = "<group>"; };
+		2A0388BC28878BD800B5DAD5 /* ColorExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ColorExtension.swift; sourceTree = "<group>"; };
+		2A68A07428921E5C004BC6A0 /* DocumentPickerViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DocumentPickerViewModel.swift; sourceTree = "<group>"; };
 		C9F39AC32887935500CD0F3F /* MockDatas.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockDatas.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -286,6 +292,7 @@
 			isa = PBXGroup;
 			children = (
 				2A0388BA28863EF300B5DAD5 /* DocumentPickerViewController.swift */,
+				2A68A07428921E5C004BC6A0 /* DocumentPickerViewModel.swift */,
 			);
 			path = DocumentPickerView;
 			sourceTree = "<group>";
@@ -445,6 +452,7 @@
 				002789C02886496E00BDCDA4 /* UIKitPreviewExtension.swift in Sources */,
 				008A5F5E288808F1006B202C /* MenuCell.swift in Sources */,
 				211B25E12887BF8F00691B87 /* SeparatedRoomView.swift in Sources */,
+				2A68A07528921E5C004BC6A0 /* DocumentPickerViewModel.swift in Sources */,
 				00F2D837288049DE00BE4176 /* SceneDelegate.swift in Sources */,
 				008A5F542887A372006B202C /* ScreenState.swift in Sources */,
 				C9E2C9FB2892235200DF5C70 /* RoomCollectionViewCell.swift in Sources */,

--- a/dorm/dorm/Presenter/DocumentPickerView/DocumentPickerViewModel.swift
+++ b/dorm/dorm/Presenter/DocumentPickerView/DocumentPickerViewModel.swift
@@ -1,0 +1,40 @@
+//
+//  DocumentPickerViewModel.swift
+//  dorm
+//
+//  Created by 한택환 on 2022/07/28.
+//
+
+import Foundation
+
+final class DocumentPickerViewModel {
+    var dormStudentData = [Student]()
+    
+    func parseCSV(url: URL) -> [Student] {
+        //TODO: .csv 파일이 내장되어 있는 경우 임시값
+        let path = Bundle.main.path(forResource: "MockData_CSV", ofType: "csv")
+        
+        var encodedData = ""
+        do {
+            let data = try Data(contentsOf: url)
+            encodedData = String(data: data, encoding: .utf8)!
+            
+        } catch {
+            print(error)
+            return []
+        }
+        
+        var csvRows = encodedData.components(separatedBy: "\n")
+        let colCount = csvRows.first?.components(separatedBy: "\n").count
+        csvRows.removeFirst()
+        
+        for csvRow in csvRows {
+            let csvColumns = csvRow.components(separatedBy: ",")
+            if csvColumns.count == colCount {
+                let studentEntity = Student.init(Int(csvColumns[0]) ?? 0, csvColumns[1], csvColumns[2], Int(csvColumns[3]) ?? 0, 0)
+                dormStudentData.append(studentEntity)
+            }
+        }
+        return dormStudentData
+    }
+}

--- a/dorm/dorm/Presenter/DocumentPickerView/DocumentPickerViewModel.swift
+++ b/dorm/dorm/Presenter/DocumentPickerView/DocumentPickerViewModel.swift
@@ -10,30 +10,25 @@ import Foundation
 final class DocumentPickerViewModel {
     var dormStudentData = [Student]()
     
-    func parseCSV(url: URL) -> [Student] {
-        //TODO: .csv 파일이 내장되어 있는 경우 임시값
-        let path = Bundle.main.path(forResource: "MockData_CSV", ofType: "csv")
-        
+    func parseCSV(url:URL) -> [Student] {
+        dormStudentData = []
         var encodedData = ""
         do {
             let data = try Data(contentsOf: url)
-            encodedData = String(data: data, encoding: .utf8)!
-            
+            encodedData = String(data: data, encoding: .utf8) ?? "error"
         } catch {
             print(error)
             return []
         }
         
         var csvRows = encodedData.components(separatedBy: "\n")
-        let colCount = csvRows.first?.components(separatedBy: "\n").count
         csvRows.removeFirst()
         
         for csvRow in csvRows {
             let csvColumns = csvRow.components(separatedBy: ",")
-            if csvColumns.count == colCount {
-                let studentEntity = Student.init(Int(csvColumns[0]) ?? 0, csvColumns[1], csvColumns[2], Int(csvColumns[3]) ?? 0, 0)
-                dormStudentData.append(studentEntity)
-            }
+            //FIXME: .csv파일에 따라 init 매개변수 변경예정 현재는 MockData_CSV.csv 에 따름
+            let studentEntity = Student.init(Int(csvColumns[1]) ?? 0, csvColumns[0], csvColumns[0], Int(csvColumns[2]) ?? 0, 0)
+            dormStudentData.append(studentEntity)
         }
         return dormStudentData
     }


### PR DESCRIPTION
## Changes
<img width="700" alt="image" src="https://user-images.githubusercontent.com/103012087/182037896-fcecab6a-fbda-4af9-b6bd-f9650abcb23e.png">

- 출력 테스트 결과

<img width="700" alt="image" src="https://user-images.githubusercontent.com/103012087/182037911-0f9e138e-dd49-4d31-8592-d65f5a6e763f.png">

- Changed files
    - DocumentPickerViewModel.swift

## New features

- .csv to StudentEntity Convertor 추가

## Review points

- .csv를 String으로 변경해서 인덱스로 접근하는 부분보다 좋은 방안이 있으면 알려주세요!
- UTType 에서 .csv를 지원하지 않아 data 타입으로 해놓은 상태인데 .csv 타입만 가져올 수 있도록 하는 방안이 있으면 조언 부탁드립니다.

## Checklist

- [x] Is the branch you are merging on correct?
- [x] Do you comply with coding conventions?
- [x] Are there any changes not related to PR?
- [x] Has my code been self-reviewed?
