### PR TITLE
Feat: Add Room Grid Cell

### DIFF
--- a/Podorm/Podorm.xcodeproj/project.pbxproj
+++ b/Podorm/Podorm.xcodeproj/project.pbxproj
@@ -23,6 +23,9 @@
 		00BBBF3228B8D0570070D177 /* Student.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00BBBF3128B8D0570070D177 /* Student.swift */; };
 		00BBBF3428B8D0620070D177 /* Room.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00BBBF3328B8D0620070D177 /* Room.swift */; };
 		00BBBF3628B8D0C10070D177 /* .swiftlint.yml in Resources */ = {isa = PBXBuildFile; fileRef = 00BBBF3528B8D0C10070D177 /* .swiftlint.yml */; };
+		00BBBF3C28B8D57B0070D177 /* RoomManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00BBBF3B28B8D57B0070D177 /* RoomManager.swift */; };
+		00BBBF3E28B8D5C40070D177 /* RoomGridCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00BBBF3D28B8D5C40070D177 /* RoomGridCell.swift */; };
+		00BBBF4028B8D6490070D177 /* MockData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00BBBF3F28B8D6490070D177 /* MockData.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -63,6 +66,9 @@
 		00BBBF3128B8D0570070D177 /* Student.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Student.swift; sourceTree = "<group>"; };
 		00BBBF3328B8D0620070D177 /* Room.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Room.swift; sourceTree = "<group>"; };
 		00BBBF3528B8D0C10070D177 /* .swiftlint.yml */ = {isa = PBXFileReference; lastKnownFileType = text.yaml; path = .swiftlint.yml; sourceTree = "<group>"; };
+		00BBBF3B28B8D57B0070D177 /* RoomManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoomManager.swift; sourceTree = "<group>"; };
+		00BBBF3D28B8D5C40070D177 /* RoomGridCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoomGridCell.swift; sourceTree = "<group>"; };
+		00BBBF3F28B8D6490070D177 /* MockData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockData.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -180,6 +186,7 @@
 		00B318C628B71C9F00B422EF /* Screen */ = {
 			isa = PBXGroup;
 			children = (
+				00BBBF3828B8D5630070D177 /* RoomManager */,
 				00B3189B28B71A6300B422EF /* ContentView.swift */,
 			);
 			path = Screen;
@@ -207,6 +214,7 @@
 			children = (
 				00BBBF3128B8D0570070D177 /* Student.swift */,
 				00BBBF3328B8D0620070D177 /* Room.swift */,
+				00BBBF3F28B8D6490070D177 /* MockData.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -226,6 +234,15 @@
 				00BBBF2F28B8CEF50070D177 /* Interactors.swift */,
 			);
 			path = Interactors;
+			sourceTree = "<group>";
+		};
+		00BBBF3828B8D5630070D177 /* RoomManager */ = {
+			isa = PBXGroup;
+			children = (
+				00BBBF3B28B8D57B0070D177 /* RoomManager.swift */,
+				00BBBF3D28B8D5C40070D177 /* RoomGridCell.swift */,
+			);
+			path = RoomManager;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -381,8 +398,10 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				00BBBF3E28B8D5C40070D177 /* RoomGridCell.swift in Sources */,
 				00BBBF2E28B8CEE80070D177 /* DIContainer.swift in Sources */,
 				00BBBF2628B8CE430070D177 /* AppState.swift in Sources */,
+				00BBBF4028B8D6490070D177 /* MockData.swift in Sources */,
 				00BBBF3028B8CEF50070D177 /* Interactors.swift in Sources */,
 				00B3189C28B71A6300B422EF /* ContentView.swift in Sources */,
 				00BBBF3428B8D0620070D177 /* Room.swift in Sources */,
@@ -390,6 +409,7 @@
 				00B3189A28B71A6300B422EF /* PodormApp.swift in Sources */,
 				00BBBF2828B8CE5D0070D177 /* Helpers.swift in Sources */,
 				00BBBF2A28B8CE620070D177 /* Loadable.swift in Sources */,
+				00BBBF3C28B8D57B0070D177 /* RoomManager.swift in Sources */,
 				00BBBF2C28B8CEB50070D177 /* Color.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Podorm/Podorm/Models/MockData.swift
+++ b/Podorm/Podorm/Models/MockData.swift
@@ -1,0 +1,35 @@
+//
+//  MockData.swift
+//  Podorm
+//
+//  Created by JongHo Park on 2022/08/26.
+//
+
+#if DEBUG
+extension Student {
+    static var mockData: [Student] = [
+        Student(2015112224, "Nick", nil, 101, 0),
+        Student(2015112224, "Jim", nil, 101, 0)
+    ]
+}
+
+extension DormRoom {
+    static var mockData: [DormRoom] = [
+        DormRoom(101, 2, []),
+        DormRoom(102, 2, []),
+        DormRoom(103, 2, []),
+        DormRoom(104, 2, []),
+        DormRoom(105, 2, []),
+        DormRoom(106, 2, []),
+        DormRoom(107, 2, []),
+        DormRoom(108, 2, []),
+        DormRoom(109, 2, []),
+        DormRoom(110, 2, []),
+        DormRoom(111, 2, []),
+        DormRoom(112, 2, []),
+        DormRoom(113, 2, []),
+        DormRoom(114, 2, []),
+        DormRoom(115, 2, [])
+    ]
+}
+#endif

--- a/Podorm/Podorm/Models/Student.swift
+++ b/Podorm/Podorm/Models/Student.swift
@@ -31,6 +31,12 @@ struct Student: Codable {
     }
 }
 
+extension Student: Equatable, Hashable {
+    static func == (lhs: Student, rhs: Student) -> Bool {
+        lhs.id == rhs.id && lhs.name == rhs.name && lhs.nickname == rhs.nickname && lhs.state == rhs.state && lhs.roomNumber == rhs.roomNumber
+    }
+}
+
 // MARK: - toString
 extension Student: CustomStringConvertible {
     var description: String {
@@ -38,8 +44,9 @@ extension Student: CustomStringConvertible {
     }
 }
 
-// MARK: - property to Readable String
+// MARK: - Public Interfaces
 extension Student {
+
     var checkInState: String {
         switch state {
         case 0:
@@ -51,3 +58,22 @@ extension Student {
         }
     }
 }
+
+// MARK: - icon
+#if canImport(SwiftUI)
+import SwiftUI
+
+// TODO: 상태에 맞는 아이콘 추가해야함
+extension Student {
+    var icon: Image {
+        switch state {
+        case 0:
+            return Image(systemName: "person.fill")
+        case 1:
+            return Image(systemName: "person.fill")
+        default:
+            fatalError("unknown checkIn status")
+        }
+    }
+}
+#endif

--- a/Podorm/Podorm/UI/Screen/RoomManager/RoomGridCell.swift
+++ b/Podorm/Podorm/UI/Screen/RoomManager/RoomGridCell.swift
@@ -1,0 +1,161 @@
+//
+//  RoomGridCell.swift
+//  Podorm
+//
+//  Created by JongHo Park on 2022/08/26.
+//
+
+import SwiftUI
+
+struct RoomGridCell: View {
+    private let room: DormRoom
+    @State private var students: Loadable<[Student]>
+    private let selected: Bool
+    private let onClick: () -> Void
+    init(room: DormRoom, selected: Bool = false, students: Loadable<[Student]> = .notRequested, _ onClick: @escaping () -> Void = {}) {
+        self.room = room
+        self._students = State(initialValue: students)
+        self.selected = selected
+        self.onClick = onClick
+    }
+
+    var body: some View {
+        VStack(alignment: .leading) {
+            Text(String(room.roomNumber))
+                .fontWeight(.semibold)
+            ZStack {
+                roundedRectangle()
+                content()
+            }
+            .frame(width: 117, height: 104, alignment: .center)
+        }
+        .onAppear {
+            loadStudents(of: room)
+        }
+    }
+}
+
+// MARK: - Common UI Componenets
+private extension RoomGridCell {
+
+    @ViewBuilder
+    func roundedRectangle() -> some View {
+        RoundedRectangle(cornerRadius: 8)
+            .stroke(Color.postechRed, lineWidth: 1)
+            .background(RoundedRectangle(cornerRadius: 8)
+                .fill(selected ? Color.postechRed : Color.clear))
+
+    }
+}
+
+// MARK: - Side Effects
+private extension RoomGridCell {
+
+    // TODO: Interact with Interactors
+    func loadStudents(of room: DormRoom) {
+        
+    }
+
+}
+
+// MARK: - Content
+private extension RoomGridCell {
+
+    @ViewBuilder
+    func content() -> some View {
+        switch students {
+        case .notRequested:
+            EmptyView()
+        case .isLoading:
+            loading()
+        case .loaded(let students):
+            loaded(students)
+        case .failed(let error):
+            failed(error)
+        }
+    }
+}
+
+// MARK: - Loading View
+private extension RoomGridCell {
+
+    func loading() -> some View {
+        VStack(spacing: 8) {
+            ProgressView()
+            Text("Loading...")
+                .fontWeight(.light)
+        }
+    }
+
+}
+
+// MARK: - Loaded View
+private extension RoomGridCell {
+
+    func loaded(_ students: [Student]) -> some View {
+        HStack(spacing: 0) {
+            ForEach(students, id: \.self) { student in
+                studentInfo(student)
+                if student != students.last {
+                    Divider()
+                        .frame(width: 1)
+                        .background(selected ? Color.white : Color.postechRed)
+                }
+            }
+        }
+        .onTapGesture(perform: onClick)
+    }
+
+    func studentInfo(_ student: Student) -> some View {
+        VStack {
+            Spacer()
+            student.icon
+                .padding(EdgeInsets(top: 0, leading: 0, bottom: 8, trailing: 0))
+            Text(student.nickname ?? student.name)
+            Spacer()
+        }
+        .foregroundColor(selected ? .white : .postechRed)
+        .frame(maxWidth: .infinity, alignment: .center)
+    }
+
+}
+
+// MARK: - Failed View
+private extension RoomGridCell {
+
+    func failed(_ error: Error) -> some View {
+        Button {
+            loadStudents(of: room)
+        } label: {
+            Text("Error occur..\nPlease retry")
+                .font(.caption)
+        }
+        .buttonStyle(.borderedProminent)
+    }
+}
+
+#if DEBUG
+// MARK: - Preview
+struct RoomGridCell_Previews: PreviewProvider {
+    static var previews: some View {
+        Group {
+            RoomGridCell(room: DormRoom.mockData.first!, students: .isLoading(last: nil))
+                .padding()
+                .previewLayout(.sizeThatFits)
+                .previewDisplayName("Loading View")
+            RoomGridCell(room: DormRoom.mockData.first!, students: .loaded(Student.mockData))
+                .padding()
+                .previewLayout(.sizeThatFits)
+                .previewDisplayName("Loaded View")
+            RoomGridCell(room: DormRoom.mockData.first!, selected: true, students: .loaded(Student.mockData))
+                .padding()
+                .previewLayout(.sizeThatFits)
+                .previewDisplayName("Selected Loaded View")
+            RoomGridCell(room: DormRoom.mockData.first!, students: .failed(NSError()))
+                .padding()
+                .previewLayout(.sizeThatFits)
+                .previewDisplayName("Failed View")
+        }
+    }
+}
+#endif

--- a/Podorm/Podorm/UI/Screen/RoomManager/RoomManager.swift
+++ b/Podorm/Podorm/UI/Screen/RoomManager/RoomManager.swift
@@ -1,0 +1,27 @@
+//
+//  RoomManager.swift
+//  Podorm
+//
+//  Created by JongHo Park on 2022/08/26.
+//
+
+import SwiftUI
+
+struct RoomManager: View {
+    @EnvironmentObject private var appState: AppState
+    @Environment(\.injected) private var diContainer: DIContainer
+
+    var body: some View {
+        Text("Room Manager View")
+    }
+}
+
+#if DEBUG
+// MARK: - Preview
+struct RoomManager_Previews: PreviewProvider {
+    static var previews: some View {
+        RoomManager()
+            .injectPreview()
+    }
+}
+#endif


### PR DESCRIPTION
## Changes

- MockData.swift -> 각 Model 의 목데이터를 추가함
- Student.swift -> 학생의 각 상태에 따라 Icon 을 반환하도록 수정, Equatable, Hasable 구현
- RoomGridCell.swift -> 각 방의 정보를 나타내는 Cell UI
- RoomManager.swift -> Room Manager UI

## New features

- Mock Data 추가
- 각 방을 받아서 방에 있는 Student 정보를 불러오는 RoomGridCell 구현

|학생 정보를 불러올 때|학생 정보를 성공적으로 불렀을 때|셀을 선택했을 때|학생 정보를 부르다 실패했을 때|
|:---:|:---:|:---:|:---:|
|<img width="135" alt="image" src="https://user-images.githubusercontent.com/57793298/186894419-5b6efb86-f4f8-48b8-b998-bbfa025a7e1c.png">|<img width="137" alt="image" src="https://user-images.githubusercontent.com/57793298/186894388-4e4b8105-2550-4622-8aa9-0414ce057a7e.png">|<img width="133" alt="image" src="https://user-images.githubusercontent.com/57793298/186894445-4dea91fb-84ec-4fb1-ae37-b299934d6338.png">|<img width="140" alt="image" src="https://user-images.githubusercontent.com/57793298/186894471-b1330e4d-3d66-4e61-a209-ad39287ec468.png">|

## Review points

- 학생 정보를 불러올 때나, 부르려다 실패했을 때의 UI 는 제가 임의로 구현했습니다! 나중에 수정이 필요해보입니다.
- [학생 정보는 각 cell 에서 state 로 관리하며, Loadable enum 을 사용해 데이터와 상태를 동시에 관리합니다.](https://github.com/DeveloperAcademy-POSTECH/MC3-Team-18-Momin/compare/develop...DeveloperAcademy-POSTECH:feature%2F%2339_grid_view?expand=1&title=Feat%3A%20Add%20Room%20Grid%20Cell#diff-a6f3f517b2cbea0f9a1ba3056f3ba36da3f90d1a568ae606e664d584aa0a9263R11-R14)
- [학생 정보 로딩 상태에 따라 UI 를 반환하는 코드](https://github.com/DeveloperAcademy-POSTECH/MC3-Team-18-Momin/compare/develop...DeveloperAcademy-POSTECH:feature%2F%2339_grid_view?expand=1&title=Feat%3A%20Add%20Room%20Grid%20Cell#diff-a6f3f517b2cbea0f9a1ba3056f3ba36da3f90d1a568ae606e664d584aa0a9263R64-R76)
- Mock Data 추가

## Checklist

- [x] Is the branch you are merging on correct?
- [x] Do you comply with coding conventions?
- [x] Are there any changes not related to PR?
- [x] Has my code been self-reviewed?
