### PR TITLE
[Feature] Room Grid View, Room Grid Cell UI 구현

### DIFF
--- a/Podorm/Podorm/Injected/AppState.swift
+++ b/Podorm/Podorm/Injected/AppState.swift
@@ -21,7 +21,11 @@ final class AppState: ObservableObject {
 extension AppState {
 
     struct UserData {
+        var dormRooms: Loadable<[DormRoom]>
 
+        init(dormRooms: Loadable<[DormRoom]> = .notRequested) {
+            self.dormRooms = dormRooms
+        }
     }
 
 }

--- a/Podorm/Podorm/Models/Room.swift
+++ b/Podorm/Podorm/Models/Room.swift
@@ -23,6 +23,12 @@ struct DormRoom: Codable {
     }
 }
 
+extension DormRoom: Equatable, Hashable {
+    static func == (lhs: DormRoom, rhs: DormRoom) -> Bool {
+        return lhs.roomNumber == rhs.roomNumber && lhs.maxNumber == rhs.maxNumber && lhs.currentMembers == rhs.currentMembers
+    }
+}
+
 // MARK: - toString
 extension DormRoom: CustomStringConvertible {
     var description: String {

--- a/Podorm/Podorm/UI/Screen/ContentView.swift
+++ b/Podorm/Podorm/UI/Screen/ContentView.swift
@@ -22,11 +22,12 @@ struct ContentView: View {
         if isRunningTests {
             Text("Running unit tests")
         } else {
-            Text("Content View")
+            RoomManager()
         }
     }
 }
 
+#if DEBUG
 // MARK: - Preview
 struct ContentView_Previews: PreviewProvider {
     static var previews: some View {
@@ -34,3 +35,4 @@ struct ContentView_Previews: PreviewProvider {
             .injectPreview()
     }
 }
+#endif

--- a/Podorm/Podorm/UI/Screen/RoomManager/RoomGridCell.swift
+++ b/Podorm/Podorm/UI/Screen/RoomManager/RoomGridCell.swift
@@ -53,7 +53,7 @@ private extension RoomGridCell {
 
     // TODO: Interact with Interactors
     func loadStudents(of room: DormRoom) {
-        
+
     }
 
 }
@@ -137,23 +137,25 @@ private extension RoomGridCell {
 #if DEBUG
 // MARK: - Preview
 struct RoomGridCell_Previews: PreviewProvider {
+
+    static func makePreview(_ students: Loadable<[Student]>, selected: Bool = false) -> some View {
+        RoomGridCell(room: DormRoom.mockData.first!, selected: selected, students: students) {
+
+        }
+        .padding()
+        .previewLayout(.sizeThatFits)
+        .previewInterfaceOrientation(.landscapeLeft)
+    }
+
     static var previews: some View {
         Group {
-            RoomGridCell(room: DormRoom.mockData.first!, students: .isLoading(last: nil))
-                .padding()
-                .previewLayout(.sizeThatFits)
+            makePreview(.isLoading(last: nil))
                 .previewDisplayName("Loading View")
-            RoomGridCell(room: DormRoom.mockData.first!, students: .loaded(Student.mockData))
-                .padding()
-                .previewLayout(.sizeThatFits)
+            makePreview(.loaded(Student.mockData))
                 .previewDisplayName("Loaded View")
-            RoomGridCell(room: DormRoom.mockData.first!, selected: true, students: .loaded(Student.mockData))
-                .padding()
-                .previewLayout(.sizeThatFits)
+            makePreview(.loaded(Student.mockData), selected: true)
                 .previewDisplayName("Selected Loaded View")
-            RoomGridCell(room: DormRoom.mockData.first!, students: .failed(NSError()))
-                .padding()
-                .previewLayout(.sizeThatFits)
+            makePreview(.failed(NSError()))
                 .previewDisplayName("Failed View")
         }
     }

--- a/Podorm/Podorm/UI/Screen/RoomManager/RoomManager.swift
+++ b/Podorm/Podorm/UI/Screen/RoomManager/RoomManager.swift
@@ -12,16 +12,106 @@ struct RoomManager: View {
     @Environment(\.injected) private var diContainer: DIContainer
 
     var body: some View {
-        Text("Room Manager View")
+        VStack {
+            content()
+        }
+        .onAppear(perform: requestDormRooms)
+        .navigationTitle("Dorm manager")
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+    }
+}
+
+// MARK: - Side Effects {
+private extension RoomManager {
+    func requestDormRooms() {
+
+    }
+}
+
+// MARK: - content
+private extension RoomManager {
+
+    @ViewBuilder
+    func content() -> some View {
+        switch appState.userData.dormRooms {
+        case .notRequested:
+            EmptyView()
+        case .isLoading:
+            loading()
+        case .loaded(let rooms):
+            loaded(rooms)
+        case .failed(let error):
+            errorIndicator(error)
+        }
+    }
+}
+
+// MARK: - Loading UI
+private extension RoomManager {
+    func loading() -> some View {
+        ProgressView()
+            .progressViewStyle(.circular)
+            .tint(.postechRed)
+            .scaleEffect(2)
+            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .center)
+    }
+}
+
+// MARK: - Loaded UI
+private extension RoomManager {
+    func loaded(_ rooms: [DormRoom]) -> some View {
+        roomGrid(rooms)
+    }
+
+    var lazyColumn: [GridItem] { [GridItem(.adaptive(minimum: 100), spacing: 24)]
+    }
+
+    func roomGrid(_ rooms: [DormRoom]) -> some View {
+        LazyVGrid(columns: lazyColumn, spacing: 60) {
+            ForEach(rooms, id: \.self) { room in
+                RoomGridCell(room: room)
+            }
+        }
+        .padding(30)
+    }
+}
+
+// MARK: - Error UI
+private extension RoomManager {
+    func errorIndicator(_ error: Error) -> some View {
+        Button {
+            requestDormRooms()
+        } label: {
+            Text("An Error occur when loading dorm rooms...\nplease try again")
+        }
+        .buttonStyle(.bordered)
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .center)
     }
 }
 
 #if DEBUG
 // MARK: - Preview
 struct RoomManager_Previews: PreviewProvider {
+
+    static func makePreview(_ roomState: Loadable<[DormRoom]>) -> some View {
+        NavigationView {
+            EmptyView()
+            RoomManager()
+        }
+        .injectPreview(AppState(AppState.UserData(dormRooms: roomState)))
+        .previewInterfaceOrientation(.landscapeLeft)
+        .tint(.postechRed)
+    }
+
     static var previews: some View {
-        RoomManager()
-            .injectPreview()
+        Group {
+            makePreview(.isLoading(last: nil))
+                .previewDisplayName("loading UI")
+            makePreview(.loaded(DormRoom.mockData))
+                .previewDisplayName("loaded UI")
+            makePreview(.failed(NSError()))
+                .previewDisplayName("error when loading")
+        }
     }
 }
 #endif


### PR DESCRIPTION
# Issue Number
🔒 Close #39 

## Changes

- AppState.swift -> DormRoom 배열 Loadable 데이터 추가
- Room.swift -> Equatable, Hashable 추가 (LazyVGrid 를 위해)
- ContentView.swift
- RoomGridCell.swift -> Preview 코드 리팩토링
- RoomManager.swift -> UI 구현

## New features

|Dorm Room 로딩 중|Dorm Room 로딩완료|로딩 중 에러 발생|
|:---:|:---:|:---:|
|<img width="500" alt="image" src="https://user-images.githubusercontent.com/57793298/187027730-f5e83cd4-5b45-4124-a13a-e9d16bef31b4.png">|<img width="513" alt="image" src="https://user-images.githubusercontent.com/57793298/187027745-2617f716-9920-46a2-8044-149969a91f2c.png">|<img width="486" alt="image" src="https://user-images.githubusercontent.com/57793298/187027759-42d3d041-4960-44c3-bc6d-4035d6469235.png">|

## Review points

- AppState 의 UserData 부분에 Loadable<[DormRoom]> 프로퍼티 추가했습니다. DormRoom 의 배열은 애플리케이션 전체 라이프사이클에서 사용될 데이터이므로, 전역으로 상태를 관리하기로 결정했습니다.

- [AppState.UserData 에서 이니셜라이저를 구현함으로써, 다양한 DormRoom 로딩 상태의 프리뷰를 표현 가능합니다. preview 코드 작성 시 [DormRoom] 의 모든 상태를 AppState.UserData 에 주입할 수 있으므로, 각 상태별 프리뷰를 쉽게 확인 가능합니다.](https://github.com/DeveloperAcademy-POSTECH/MC3-Team-18-Momin/compare/develop...DeveloperAcademy-POSTECH:feature%2F%2339_add_grid_view?expand=1&title=39%20%5BFeature%5D%20Room%20Grid%20View%2C%20Room%20Grid%20Cell%20UI%20구현#diff-89ea8e3f8ffdab77e2f184289023c4713260b98700125c2d0baba9b9556b9301R23-R31)

## Checklist

- [x] Is the branch you are merging on correct?
- [x] Do you comply with coding conventions?
- [x] Are there any changes not related to PR?
- [x] Has my code been self-reviewed?
